### PR TITLE
SECURITY-1420: Remove SUID from login_duo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,7 +104,7 @@ class profile_duo (
     ensure  => present,
     owner   => 'root',
     group   => 'root',
-    mode    => '4755',
+    mode    => '0755',
     require => Package[$package];
   }
 


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/SECURITY-1420

The login-duo file does not need to be set SUID when used with Pam auth.

This is being tested on:
- `linux-test`
- `dt-login03`