### PR TITLE
SVC-20379: Default to failmode: secure

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,7 +1,7 @@
 ---
 profile_duo::accept_env_factor: "no"
 profile_duo::autopush: "no"
-profile_duo::failmode: "safe"
+profile_duo::failmode: "secure"
 profile_duo::fallback_local_ip: "no"
 profile_duo::group: ""
 profile_duo::host: ""


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/SVC-20379

This is being tested on `linux-test`.