### PR TITLE
SVC-22397: Set yum priority for DUO yum repo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,7 +82,7 @@ class profile_duo (
     fail('ikey, skey, and host must all be defined.')
   }
 
-  ## install Pakrat Yum repo for Duo
+  ## install Yum repo for Duo
   yumrepo { $yumrepo_name:
     ensure   => 'present',
     enabled  => 1,
@@ -90,6 +90,7 @@ class profile_duo (
     baseurl  => $yumrepo_baseurl,
     gpgcheck => 1,
     gpgkey   => $yumrepo_gpgkey,
+    priority => 1,
   }
 
   ## INSTALL $package


### PR DESCRIPTION
Fix #7 to prioritize the DUO repo configured by this module.

This is tested on `linux-test`.